### PR TITLE
Support multiple webpack builds

### DIFF
--- a/Webpack.NET.Tests/TestUrlHelperExtensions.cs
+++ b/Webpack.NET.Tests/TestUrlHelperExtensions.cs
@@ -28,12 +28,7 @@ namespace Webpack.NET.Tests
 		{
 			var urlHelper = SetupUrlHelper("http://server/");
 			var webpack   = new Mock<IWebpack>();
-			var assets    = new WebpackAssetsDictionary
-			{
-				["asset-name"] = new WebpackAsset { { "ext", "asset.hash.js" } }
-			};
-			webpack.Setup(w => w.Config).Returns(new WebpackConfig { AssetOutputPath = "~/scripts/assets" });
-			webpack.Setup(w => w.Assets).Returns(assets);
+			webpack.Setup(w => w.GetAssetUrl("asset-name", "ext")).Returns("/scripts/assets/asset.hash.js");
 			urlHelper.RequestContext.HttpContext.Application.ConfigureWebpack(webpack.Object);
 			
 			Assert.That(urlHelper.WebpackAsset("asset-name", "ext"), Is.EqualTo("/scripts/assets/asset.hash.js"));

--- a/Webpack.NET.Tests/TestWebpack.cs
+++ b/Webpack.NET.Tests/TestWebpack.cs
@@ -15,52 +15,88 @@ namespace Webpack.NET.Tests
 	{
 		private WebpackConfig _config;
 		private Mock<HttpServerUtilityBase> _server;
-		private string _tempFile;
+		private List<string> _tempFiles;
 
 		[SetUp]
 		public void Setup()
 		{
-			_config   = new WebpackConfig();
-			_server   = new Mock<HttpServerUtilityBase>();
-			_tempFile = Path.GetTempFileName();
+			_config    = new WebpackConfig();
+			_server    = new Mock<HttpServerUtilityBase>();
+			_tempFiles = new List<string>();
 		}
 
 		[TearDown]
 		public void TearDown()
 		{
-			if (File.Exists(_tempFile))
-				File.Delete(_tempFile);
+			foreach (var tempFile in _tempFiles)
+				if (File.Exists(tempFile))
+					File.Delete(tempFile);
 		}
 
 		[Test]
 		public void Constructor_Throws_On_Null_Parameters()
 		{
 			Assert.Throws<ArgumentNullException>(() => new Webpack(null, _server.Object));
-			Assert.Throws<ArgumentNullException>(() => new Webpack(new WebpackConfig(), null));
-		}
-
-		[Test]
-		public void Config_Exposes_Constructor_Value()
-		{
-			var webpack = new Webpack(_config, _server.Object);
-			Assert.That(webpack.Config, Is.SameAs(_config));
+			Assert.Throws<ArgumentNullException>(() => new Webpack(new[] { new WebpackConfig() }, null));
 		}
 
 		[Test]
 		public void Assets_Are_Lazily_Loaded()
 		{
-			var webpack = new Webpack(_config, _server.Object);
+			var webpack = new Webpack(new[] { _config }, _server.Object);
 			_server.Verify(s => s.MapPath(It.IsAny<string>()), Times.Never());
 
-			_server.Setup(s => s.MapPath("~/scripts/manifest.json")).Returns(_tempFile);
 			_config.AssetManifestPath = "~/scripts/manifest.json";
-			File.WriteAllText(_tempFile, @"{ ""file"": { ""js"": ""file.js"" } }");
+			_config.AssetOutputPath   = "~/dist";
 
-			Assert.That(webpack.GetAssetUrl("file", "js"), Is.EqualTo("file.js"));
+			SetupManifestFile(_config.AssetManifestPath, @"{ ""file"": { ""js"": ""file.js"" } }");
+
+			Assert.That(webpack.GetAssetUrl("file", "js"), Is.EqualTo("~/dist/file.js"));
 			_server.Verify(s => s.MapPath(It.IsAny<string>()), Times.Once());
 
-			Assert.That(webpack.GetAssetUrl("file", "js"), Is.EqualTo("file.js"));
+			Assert.That(webpack.GetAssetUrl("file", "js"), Is.EqualTo("~/dist/file.js"));
 			_server.Verify(s => s.MapPath(It.IsAny<string>()), Times.Once());
+		}
+
+		[Test]
+		public void Assets_Can_Be_Retrieved_From_Multiple_Configurations()
+		{
+			var config1 = new WebpackConfig { AssetManifestPath = "~/scripts/manifest1.json", AssetOutputPath = "~/dist/1" };
+			var config2 = new WebpackConfig { AssetManifestPath = "~/scripts/manifest2.json", AssetOutputPath = "~/dist/2" };
+
+			SetupManifestFile(config1.AssetManifestPath, @"{ ""code"": { ""js"": ""file.1.js"" } }");
+			SetupManifestFile(config2.AssetManifestPath, @"{ ""style"": { ""css"": ""file.2.css"" } }");
+			
+			var webpack = new Webpack(new[] { config1, config2 }, _server.Object);
+			Assert.That(webpack.GetAssetUrl("code", "js"), Is.EqualTo("~/dist/1/file.1.js"));
+			Assert.That(webpack.GetAssetUrl("style", "css"), Is.EqualTo("~/dist/2/file.2.css"));
+		}
+
+		[Test]
+		public void GetAssetUrl_Returns_Null_When_No_Configurations_Specified()
+		{
+			var webpack = new Webpack(new WebpackConfig[0], _server.Object);
+			Assert.Throws<AssetNotFoundException>(() => webpack.GetAssetUrl("any", "any"));
+		}
+
+		[Test]
+		public void GetAssetUrl_Returns_Null_When_No_Matching_Resource()
+		{
+			_config.AssetManifestPath = "~/scripts/manifest.json";
+			SetupManifestFile(_config.AssetManifestPath, @"{ ""file"": { ""js"": ""file.js"" } }");
+
+			var webpack = new Webpack(new[] { _config }, _server.Object);
+			Assert.Throws<AssetNotFoundException>(() => webpack.GetAssetUrl("non-existant", "js"));
+			Assert.Throws<AssetNotFoundException>(() => webpack.GetAssetUrl("file", "non-existant"));
+			Assert.Throws<AssetNotFoundException>(() => webpack.GetAssetUrl("non-existant", "non-existant"));
+		}
+
+		private void SetupManifestFile(string manifestPath, string manifestContent)
+		{
+			var tempFile = Path.GetTempFileName();
+			_tempFiles.Add(tempFile);
+			_server.Setup(s => s.MapPath(manifestPath)).Returns(tempFile);
+			File.WriteAllText(tempFile, manifestContent);
 		}
 	}
 }

--- a/Webpack.NET.Tests/TestWebpack.cs
+++ b/Webpack.NET.Tests/TestWebpack.cs
@@ -56,10 +56,10 @@ namespace Webpack.NET.Tests
 			_config.AssetManifestPath = "~/scripts/manifest.json";
 			File.WriteAllText(_tempFile, @"{ ""file"": { ""js"": ""file.js"" } }");
 
-			Assert.That(webpack.Assets["file"]["js"], Is.EqualTo("file.js"));
+			Assert.That(webpack.GetAssetUrl("file", "js"), Is.EqualTo("file.js"));
 			_server.Verify(s => s.MapPath(It.IsAny<string>()), Times.Once());
 
-			Assert.That(webpack.Assets["file"]["js"], Is.EqualTo("file.js"));
+			Assert.That(webpack.GetAssetUrl("file", "js"), Is.EqualTo("file.js"));
 			_server.Verify(s => s.MapPath(It.IsAny<string>()), Times.Once());
 		}
 	}

--- a/Webpack.NET/AssetNotFoundException.cs
+++ b/Webpack.NET/AssetNotFoundException.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Webpack.NET
+{
+
+	[Serializable]
+	public class AssetNotFoundException : Exception
+	{
+		public AssetNotFoundException(string assetName, string assetType)
+		: base($"Asset {assetName} with type {assetType} could not be found") { }
+		
+		protected AssetNotFoundException(
+		  System.Runtime.Serialization.SerializationInfo info,
+		  System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
+	}
+}

--- a/Webpack.NET/ConfigurationExtensions.cs
+++ b/Webpack.NET/ConfigurationExtensions.cs
@@ -11,12 +11,12 @@ namespace Webpack.NET
 	public static class ConfigurationExtensions
 	{
 		[ExcludeFromCodeCoverage]
-		public static void ConfigureWebpack(this HttpApplication application, WebpackConfig config)
+		public static void ConfigureWebpack(this HttpApplication application, params WebpackConfig[] configs)
 		{
 			if (application == null) throw new ArgumentNullException(nameof(application));
 
 			new HttpApplicationStateWrapper(application.Application)
-				.ConfigureWebpack(new Webpack(new[] { config }, new HttpServerUtilityWrapper(application.Server)));
+				.ConfigureWebpack(new Webpack(configs, new HttpServerUtilityWrapper(application.Server)));
 		}
 
 		internal static void ConfigureWebpack(this HttpApplicationStateBase application, IWebpack webpack)

--- a/Webpack.NET/ConfigurationExtensions.cs
+++ b/Webpack.NET/ConfigurationExtensions.cs
@@ -16,7 +16,7 @@ namespace Webpack.NET
 			if (application == null) throw new ArgumentNullException(nameof(application));
 
 			new HttpApplicationStateWrapper(application.Application)
-				.ConfigureWebpack(new Webpack(config, new HttpServerUtilityWrapper(application.Server)));
+				.ConfigureWebpack(new Webpack(new[] { config }, new HttpServerUtilityWrapper(application.Server)));
 		}
 
 		internal static void ConfigureWebpack(this HttpApplicationStateBase application, IWebpack webpack)

--- a/Webpack.NET/IWebpack.cs
+++ b/Webpack.NET/IWebpack.cs
@@ -2,7 +2,8 @@
 {
 	internal interface IWebpack
 	{
-		WebpackAssetsDictionary Assets { get; }
+		string GetAssetUrl(string assetName, string assetType);
+
 		WebpackConfig Config { get; }
 	}
 }

--- a/Webpack.NET/IWebpack.cs
+++ b/Webpack.NET/IWebpack.cs
@@ -3,7 +3,5 @@
 	internal interface IWebpack
 	{
 		string GetAssetUrl(string assetName, string assetType);
-
-		WebpackConfig Config { get; }
 	}
 }

--- a/Webpack.NET/UrlHelperExtensions.cs
+++ b/Webpack.NET/UrlHelperExtensions.cs
@@ -17,7 +17,7 @@ namespace Webpack.NET
 			if (urlHelper == null) throw new ArgumentNullException(nameof(urlHelper));
 
 			var webpack = urlHelper.RequestContext.HttpContext.Application.GetWebpack();
-			return urlHelper.Content($"{webpack.Config.AssetOutputPath}/{webpack.Assets[assetName][assetType]}");
+			return urlHelper.Content(webpack.GetAssetUrl(assetName, assetType));
 		}
 
 		public static string AbsoluteWebpackAsset(this UrlHelper urlHelper, string assetName = "main", string assetType = "js")
@@ -25,7 +25,7 @@ namespace Webpack.NET
 			if (urlHelper == null) throw new ArgumentNullException(nameof(urlHelper));
 
 			var webpack  = urlHelper.RequestContext.HttpContext.Application.GetWebpack();
-			var relative = urlHelper.Content($"{webpack.Config.AssetOutputPath}/{webpack.Assets[assetName][assetType]}");
+			var relative = urlHelper.Content(webpack.GetAssetUrl(assetName, assetType));
 			return new Uri(urlHelper.RequestContext.HttpContext.Request.Url, relative).ToString();
 		}
 	}

--- a/Webpack.NET/Webpack.cs
+++ b/Webpack.NET/Webpack.cs
@@ -22,6 +22,9 @@ namespace Webpack.NET
 
 		public WebpackConfig Config { get; private set; }
 
-		public WebpackAssetsDictionary Assets { get => _assets.Value; }
+		public string GetAssetUrl(string assetName, string assetType)
+		{
+			return _assets.Value[assetName][assetType];
+		}
 	}
 }

--- a/Webpack.NET/WebpackAssetsDictionary.cs
+++ b/Webpack.NET/WebpackAssetsDictionary.cs
@@ -10,6 +10,8 @@ namespace Webpack.NET
 {
 	internal class WebpackAssetsDictionary : Dictionary<string, WebpackAsset>
 	{
+		public string RootFolder { get; set; }
+
 		internal static WebpackAssetsDictionary FromFile(string assetJsonPath)
 		{
 			var serializer = new JsonSerializer();


### PR DESCRIPTION
We may have multiple webpack outputs (e.g. one for `less`, one for `ts`) and those will probably output to different folders.

They will _definitely_ output different `webpack-assets.json` files too.

This change means we can support multiple independent webpack builds and still embed the assets