### PR TITLE
Fixed AbsoluteWebpackAsset Uri encoding

### DIFF
--- a/Webpack.NET/UrlHelperExtensions.cs
+++ b/Webpack.NET/UrlHelperExtensions.cs
@@ -24,9 +24,8 @@ namespace Webpack.NET
 		{
 			if (urlHelper == null) throw new ArgumentNullException(nameof(urlHelper));
 
-			var webpack  = urlHelper.RequestContext.HttpContext.Application.GetWebpack();
-			var relative = urlHelper.Content(webpack.GetAssetUrl(assetName, assetType));
-			return new Uri(urlHelper.RequestContext.HttpContext.Request.Url, relative).ToString();
+			var relative = urlHelper.WebpackAsset(assetName, assetType);
+			return new Uri(urlHelper.RequestContext.HttpContext.Request.Url, relative).AbsoluteUri;
 		}
 	}
 }


### PR DESCRIPTION
Changed `new Uri().ToString()` to `new Uri().AbsoluteUri`, so it is correctly encoded (http://faithlife.codes/blog/2010/08/uritostring_must_die/) and removed duplicated code.